### PR TITLE
correction to the wording regarding RFC5198

### DIFF
--- a/docs/telnet/charset.md
+++ b/docs/telnet/charset.md
@@ -10,8 +10,10 @@ description: Allows client to inform server about terminal screen size
 
 Early versions of Telnet assumed that ASCII charset is in use. This telnet option allowed switching to a different charset.
 
-Since [RFC 5198](https://www.rfc-editor.org/rfc/rfc5198) UTF-8 character encoding along with Unicode charset is the new default, 
-but it may still be useful to explicitly agree on this.
+[RFC 5198](https://www.rfc-editor.org/rfc/rfc5198) introduces a default of UTF-8 for new protocols going forward,
+but notes in Appendix D that further work on a new telnet option would be needed to retrofit this to telnet, and does
+not change existing protocols.
+
 
 | Tokens         | Bytes      | Meaning                                           |
 | -------------- | ---------- | ------------------------------------------------- |


### PR DESCRIPTION
 RFC5198 is not retroactive and appendix D specifically denies applicability to telnet by suggesting a new telnet option for UTF-8 to be negotiated

from section 1.1, it says
> This document proposes to establish "Net-Unicode" as a new
> standardized text transmission form for the Internet, to serve as an
> internationalized alternative for NVT ASCII **when specified in new** --
> **and, where appropriate, updated -- protocols**.

(my emphasis)

and from Appendix D:

> Consideration should be given to a Telnet (or SSH [[RFC4251](https://www.rfc-editor.org/rfc/rfc4251)]) option
>  to specify this type of stream and an FTP extension [[RFC0959](https://www.rfc-editor.org/rfc/rfc0959)] to
> permit a new "Unicode text" data TYPE.